### PR TITLE
feat: Add W3Cache for TX receipt and block caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Development
+
+## Commands
+
+```bash
+tox -e lint    # isort, black, flake8
+tox -e test    # pytest with coverage
+tox -e build   # build wheel + sdist
+
+pytest                          # run tests directly
+pytest tests/test_foo.py        # single file
+pytest tests/ -k "event_parser" # filtered suite
+```
+
+## Config quirks
+
+- Line length: **120** (black + flake8, see `setup.cfg` and `pyproject.toml`)
+- Black ignores flake8's E203/W503 — do not "fix" those
+- Pyright uses `venv/` (not `.venv/`); configured in `pyrightconfig.json`
+- Source lives in `src/eth_pretty_events/`, not the repo root
+
+## Dependencies
+
+Core: `web3>=7.8`, `PyYAML`
+Extras: `pytest` + `pytest-asyncio` + `factory_boy` (testing); `Flask` (flask); `google-cloud-pubsub` (pubsub); `Jinja2` (templates)
+
+Install with: `pip install -e ".[testing,flask,pubsub]"`
+
+## Environment
+
+Required env vars (see `.env.sample`):
+- `RPC_URL` — Ethereum RPC endpoint
+- `ABI_PATHS` — space-separated ABI file directories
+- `TEMPLATE_PATHS` — Jinja2 template directories
+- `TEMPLATE_RULES` — YAML mapping event signatures to templates
+- `ADDRESS_BOOK` — JSON map of addresses to names
+- `CHAINS_FILE` — JSON chain metadata
+- `BYTES32_RAINBOW` — JSON map of bytes32 role hashes to names
+- `DISCORD_URL` — Discord webhook (for output)
+
+## Architecture
+
+- `cli.py` — CLI entrypoint (`pip install -e .` gives `script_name` command)
+- `flask_app.py` — Flask app; receives Alchemy webhooks, validates signature
+- `event_filter.py` — filters events by configurable rules
+- `event_parser.py` — parses EVM events
+- `render.py` / `jinja2_ext.py` — Jinja2 templating helpers
+- `outputs.py` / `discord.py` / `print_output.py` / `pubsub.py` — output plugins (auto-loaded)
+- `w3cache.py` — Web3 HTTP provider with retry/cache
+
+## Testing
+
+- Tests use **function-style** (e.g., `def test_foo():`), **not** class-based (`class Test:`)

--- a/src/eth_pretty_events/cli.py
+++ b/src/eth_pretty_events/cli.py
@@ -230,8 +230,7 @@ async def parse_raw_events(
             tx_logs = list(tx_logs)
             tx_logs = list({log["logIndex"]: log for log in tx_logs}.values())
             tx = Tx(Hash(tx_hash), tx_logs[0]["transactionIndex"], block)
-            decoded_events = list(decode_events.decode_events_from_raw_logs(block, tx, tx_logs))
-            decoded_log = DecodedTxLogs(tx, tx_logs, decoded_events)
+            decoded_log = DecodedTxLogs(tx, tx_logs)
             for queue in processed_logs:
                 await queue.put(decoded_log)
         raw_logs.task_done()
@@ -322,20 +321,17 @@ def merge_decoded_logs(same_tx_group: Iterable[DecodedTxLogs]) -> DecodedTxLogs:
         raise ValueError("merge_decoded_logs() received an empty group")
 
     base = tx_logs_list[0]
-    by_log_index: dict[int, tuple[object, object]] = {}
+    by_log_index: dict[int, web3types.LogReceipt] = {}
 
     for tx_logs in tx_logs_list:
-        if len(tx_logs.raw_logs) != len(tx_logs.decoded_logs):
-            raise ValueError("raw_logs and decoded_logs must have the same length")
-        for raw, dec in zip(tx_logs.raw_logs, tx_logs.decoded_logs):
+        for raw in tx_logs.raw_logs:
             idx = raw["logIndex"]
-            by_log_index.setdefault(idx, (raw, dec))
+            by_log_index.setdefault(idx, raw)
 
     ordered = [by_log_index[i] for i in sorted(by_log_index)]
     if ordered:
-        raw, dec = zip(*ordered)
-        return DecodedTxLogs(tx=base.tx, raw_logs=list(raw), decoded_logs=list(dec))
-    return DecodedTxLogs(tx=base.tx, raw_logs=[], decoded_logs=[])
+        return DecodedTxLogs(tx=base.tx, raw_logs=list(ordered))
+    return DecodedTxLogs(tx=base.tx, raw_logs=[])
 
 
 def _consolidate_logs(decoded_logs_for_sub: Iterable[Iterable[DecodedTxLogs]]) -> Iterator[DecodedTxLogs]:

--- a/src/eth_pretty_events/cli.py
+++ b/src/eth_pretty_events/cli.py
@@ -28,7 +28,7 @@ try:
     from . import pubsub  # noqa - To load the pubsub output
 except ImportError:
     pass
-from . import __version__, address_book, decode_events, render
+from . import __version__, address_book, decode_events, render, w3cache
 from .block_tree import BlockTree
 from .event_filter import TemplateRule, read_template_rules
 from .event_parser import EventDefinition
@@ -395,10 +395,12 @@ def render_events(renv: RenderingEnv, input: str):
         if renv.w3 is None:
             raise argparse.ArgumentTypeError("Missing --rpc-url parameter")
         with open(input) as f:
-            tx_hashes = (line.strip() for line in f if line.strip())
-            decoded_tx_logs = [
-                decode_events.decode_events_from_tx(tx_hash, renv.w3, renv.chain) for tx_hash in tx_hashes
-            ]
+            tx_hashes = [line.strip() for line in f if line.strip()]
+        w3cache_instance = w3cache.W3Cache(renv.w3)
+        w3cache_instance.preload_receipts(tx_hashes)
+        decoded_tx_logs = [
+            decode_events.decode_events_from_tx(tx_hash, w3cache_instance, renv.chain) for tx_hash in tx_hashes
+        ]
     elif input.isdigit():
         if renv.w3 is None:
             raise argparse.ArgumentTypeError("Missing --rpc-url parameter")

--- a/src/eth_pretty_events/decode_events.py
+++ b/src/eth_pretty_events/decode_events.py
@@ -1,15 +1,13 @@
 import itertools
 import logging
 from operator import itemgetter
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable
 
 from web3 import Web3
-from web3 import types as web3types
 
 from .alchemy_utils import graphql_log_to_log_receipt
-from .event_parser import EventDefinition
 from .outputs import DecodedTxLogs
-from .types import Block, Chain, Event, Hash, Tx
+from .types import Block, Chain, Hash, Tx
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +31,7 @@ def decode_from_alchemy_input(alchemy_input: dict, chain: Chain) -> Iterable[Dec
         )
         alchemy_logs = list({log["index"]: log for log in alchemy_logs}.values())
         raw_logs = [graphql_log_to_log_receipt(alchemy_log, alchemy_block) for alchemy_log in alchemy_logs]
-        decoded_logs = decode_events_from_raw_logs(block, tx, raw_logs)
-
-        yield DecodedTxLogs(tx=tx, raw_logs=raw_logs, decoded_logs=decoded_logs)
+        yield DecodedTxLogs(tx=tx, raw_logs=raw_logs)
 
 
 def decode_events_from_tx(tx_hash: str, w3: Web3, chain: Chain) -> DecodedTxLogs:
@@ -47,13 +43,7 @@ def decode_events_from_tx(tx_hash: str, w3: Web3, chain: Chain) -> DecodedTxLogs
         timestamp=w3.eth.get_block(receipt.blockNumber).timestamp,
     )
     tx = Tx(block=block, hash=Hash(receipt.transactionHash), index=receipt.transactionIndex)
-    return DecodedTxLogs(
-        tx=tx, raw_logs=receipt.logs, decoded_logs=decode_events_from_raw_logs(block, tx, receipt.logs)
-    )
-
-
-def decode_events_from_raw_logs(block: Block, tx: Tx, logs: Sequence[web3types.LogReceipt]) -> List[Optional[Event]]:
-    return [EventDefinition.read_log(log, block=block, tx=tx) for log in logs]
+    return DecodedTxLogs(tx=tx, raw_logs=receipt.logs)
 
 
 def decode_events_from_block(block_number: int, w3: Web3, chain: Chain) -> Iterable[DecodedTxLogs]:
@@ -64,9 +54,7 @@ def decode_events_from_block(block_number: int, w3: Web3, chain: Chain) -> Itera
         tx_hash = Hash(w3_tx)
         receipt = w3.eth.get_transaction_receipt(w3_tx)
         tx = Tx(block=block, hash=tx_hash, index=receipt.transactionIndex)
-        yield DecodedTxLogs(
-            tx=tx, raw_logs=receipt.logs, decoded_logs=decode_events_from_raw_logs(block, tx, receipt.logs)
-        )
+        yield DecodedTxLogs(tx=tx, raw_logs=receipt.logs)
 
 
 def decode_events_from_subscription(subscription, w3: Web3, chain: Chain, block_from: int, block_to: int):
@@ -78,9 +66,7 @@ def decode_events_from_subscription(subscription, w3: Web3, chain: Chain, block_
         log_filter["topics"] = topics
 
     for block, tx, logs_for_tx in fetch_logs(w3, chain, log_filter, block_from, block_to):
-        yield DecodedTxLogs(
-            tx=tx, raw_logs=logs_for_tx, decoded_logs=decode_events_from_raw_logs(block, tx, logs_for_tx)
-        )
+        yield DecodedTxLogs(tx=tx, raw_logs=logs_for_tx)
 
 
 def fetch_logs(w3, chain: Chain, log_filter: dict, block_from: int, block_to: int):

--- a/src/eth_pretty_events/decode_events.py
+++ b/src/eth_pretty_events/decode_events.py
@@ -50,11 +50,13 @@ def decode_events_from_block(block_number: int, w3: Web3, chain: Chain) -> Itera
     w3_block = w3.eth.get_block(block_number)
     block = Block(chain=chain, number=block_number, timestamp=w3_block["timestamp"], hash=Hash(w3_block["hash"]))
 
-    for w3_tx in w3_block.transactions:
-        tx_hash = Hash(w3_tx)
-        receipt = w3.eth.get_transaction_receipt(w3_tx)
-        tx = Tx(block=block, hash=tx_hash, index=receipt.transactionIndex)
-        yield DecodedTxLogs(tx=tx, raw_logs=receipt.logs)
+    tx_hashes = [str(tx) for tx in w3_block.transactions]
+    if tx_hashes:
+        batch = w3.batch_requests()
+        batch.add_mapping({w3.eth.get_transaction_receipt: tx_hashes})
+        for tx_hash, receipt in zip(tx_hashes, batch.execute()):
+            tx = Tx(block=block, hash=Hash(tx_hash), index=receipt.transactionIndex)
+            yield DecodedTxLogs(tx=tx, raw_logs=receipt.logs)
 
 
 def decode_events_from_subscription(subscription, w3: Web3, chain: Chain, block_from: int, block_to: int):

--- a/src/eth_pretty_events/outputs.py
+++ b/src/eth_pretty_events/outputs.py
@@ -2,11 +2,13 @@ import asyncio
 import pprint
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Iterable, List, Optional
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from web3 import types as web3types
 
+from .event_parser import EventDefinition
 from .types import Event, Tx
 
 
@@ -14,7 +16,10 @@ from .types import Event, Tx
 class DecodedTxLogs:
     tx: Tx
     raw_logs: List[web3types.LogReceipt]
-    decoded_logs: List[Optional[Event]]
+
+    @cached_property
+    def decoded_logs(self) -> List[Optional[Event]]:
+        return [EventDefinition.read_log(log, block=self.tx.block, tx=self.tx) for log in self.raw_logs]
 
 
 class OutputBase(ABC):

--- a/src/eth_pretty_events/w3cache.py
+++ b/src/eth_pretty_events/w3cache.py
@@ -1,0 +1,53 @@
+from typing import Dict, Sequence, Union
+
+from web3 import Web3
+from web3 import types as web3types
+
+
+class W3Cache:
+    """Web3 wrapper with TX receipt and block caching."""
+
+    def __init__(self, w3: Web3):
+        self._w3 = w3
+        self._receipt_cache: Dict[str, web3types.TxReceipt] = {}
+        self._block_cache: Dict[int, web3types.BlockData] = {}
+
+    @property
+    def eth(self) -> "W3Cache":
+        return self
+
+    def is_connected(self) -> bool:
+        return self._w3.is_connected
+
+    def get_transaction_receipt(self, tx_hash: str) -> web3types.TxReceipt:
+        tx_hash = tx_hash.lower()
+        if tx_hash in self._receipt_cache:
+            return self._receipt_cache[tx_hash]
+        receipt = self._w3.eth.get_transaction_receipt(tx_hash)
+        self._receipt_cache[tx_hash] = receipt
+        return receipt
+
+    def get_block(self, block_identifier: Union[int, str]) -> web3types.BlockData:
+        if isinstance(block_identifier, int):
+            if block_identifier in self._block_cache:
+                return self._block_cache[block_identifier]
+            block = self._w3.eth.get_block(block_identifier)
+            self._block_cache[block_identifier] = block
+            return block
+        return self._w3.eth.get_block(block_identifier)
+
+    def get_logs(self, filter_params: dict) -> Sequence[web3types.LogReceipt]:
+        return self._w3.eth.get_logs(filter_params)
+
+    def preload_receipts(self, tx_hashes: Sequence[str], batch_size: int = 50):
+        """Pre-load TX receipts using batched RPC calls."""
+        uncached = [h.lower() for h in tx_hashes if h.lower() not in self._receipt_cache]
+        for i in range(0, len(uncached), batch_size):
+            batch = self._w3.batch_requests()
+            batch.add_mapping(
+                {
+                    self._w3.eth.get_transaction_receipt: uncached[i : i + batch_size],
+                }
+            )
+            for receipt in batch.execute():
+                self._receipt_cache[receipt.transactionHash.lower()] = receipt

--- a/src/eth_pretty_events/w3cache.py
+++ b/src/eth_pretty_events/w3cache.py
@@ -51,3 +51,20 @@ class W3Cache:
             )
             for receipt in batch.execute():
                 self._receipt_cache[receipt.transactionHash.lower()] = receipt
+
+        uncached_blocks = {
+            receipt.blockNumber
+            for receipt in self._receipt_cache.values()
+            if receipt.blockNumber is not None and receipt.blockNumber not in self._block_cache
+        }
+        if uncached_blocks:
+            block_list = sorted(uncached_blocks)
+            for i in range(0, len(block_list), batch_size):
+                batch = self._w3.batch_requests()
+                batch.add_mapping(
+                    {
+                        self._w3.eth.get_block: block_list[i : i + batch_size],
+                    }
+                )
+                for block in batch.execute():
+                    self._block_cache[block.number] = block

--- a/src/eth_pretty_events/w3cache.py
+++ b/src/eth_pretty_events/w3cache.py
@@ -16,9 +16,6 @@ class W3Cache:
     def eth(self) -> "W3Cache":
         return self
 
-    def is_connected(self) -> bool:
-        return self._w3.is_connected
-
     def get_transaction_receipt(self, tx_hash: str) -> web3types.TxReceipt:
         tx_hash = tx_hash.lower()
         if tx_hash in self._receipt_cache:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from eth_pretty_events.cli import (
     render_events,
 )
 from eth_pretty_events.types import Chain
+from eth_pretty_events.w3cache import W3Cache
 
 __author__ = "Guillermo M. Narvaja"
 __copyright__ = "Guillermo M. Narvaja"
@@ -313,8 +314,9 @@ def test_render_events_txt_file_parses_hashes(mock_renv, txt_file):
         render_events(mock_renv, str(txt_file))
 
         assert mock_decode.call_count == 2
-        mock_decode.assert_any_call(TX_HASH_1, mock_renv.w3, mock_renv.chain)
-        mock_decode.assert_any_call(TX_HASH_2, mock_renv.w3, mock_renv.chain)
+        for call in mock_decode.call_args_list:
+            args, _ = call
+            assert isinstance(args[1], W3Cache)
 
 
 @pytest.mark.parametrize("txt_file", ["empty", "only_whitespace"], indirect=True)

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -169,7 +169,8 @@ def test_build_transaction_messages_limits(dummy_renv, template_rules, template_
 async def test_run_webhook_response(setup_output, alchemy_sample_events, mock_tx):
     output, queue, app = setup_output
     raw_logs = [{} for _ in alchemy_sample_events]  # Not used in this test, just needs to be the same length
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs, decoded_logs=alchemy_sample_events)
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs)
+    decoded_logs.decoded_logs = alchemy_sample_events
     task = asyncio.create_task(output.run(queue))
     await queue.put(decoded_logs)
     await asyncio.sleep(1)
@@ -194,7 +195,8 @@ def test_run_sync_with_valid_messages(dummy_renv, template_rules, template_loade
         with patch.dict("os.environ", {"DISCORD_URL": "https://discord.com/api/webhooks/test"}):
             output = DiscordOutput(urlparse(url), dummy_renv)
 
-            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[], decoded_logs=alchemy_sample_events)
+            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[])
+            decoded_logs.decoded_logs = alchemy_sample_events
 
             output.run_sync([decoded_logs])
 
@@ -249,7 +251,8 @@ async def test_run_warning_logs(
     with patch.dict("os.environ", {"DISCORD_URL": str(webhook_url)}):
         output = DiscordOutput(urlparse(url), dummy_renv)
         raw_logs = [{} for _ in alchemy_sample_events]  # Not used in this test, just needs to be the same length
-        decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs, decoded_logs=alchemy_sample_events)
+        decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs)
+        decoded_logs.decoded_logs = alchemy_sample_events
 
         with caplog.at_level("WARNING"):
             task = asyncio.create_task(output.run(queue))
@@ -287,7 +290,8 @@ async def test_run_warning_logs_400(
     with patch.dict("os.environ", {"DISCORD_URL": str(webhook_url)}):
         output = DiscordOutput(urlparse(url), dummy_renv)
         raw_logs = [{} for _ in alchemy_sample_events]
-        decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs, decoded_logs=alchemy_sample_events)
+        decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs)
+        decoded_logs.decoded_logs = alchemy_sample_events
 
         with caplog.at_level("WARNING"):
             task = asyncio.create_task(output.run(queue))
@@ -313,7 +317,8 @@ def test_run_sync_with_warning_logs(
         with patch.dict("os.environ", {"DISCORD_URL": "https://discord.com/api/webhooks/test"}):
             output = DiscordOutput(urlparse(url), dummy_renv)
             raw_logs = [{} for _ in alchemy_sample_events]  # Not used in this test, just needs to be the same length
-            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs, decoded_logs=alchemy_sample_events)
+            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs)
+            decoded_logs.decoded_logs = alchemy_sample_events
 
             with caplog.at_level("WARNING"):
                 output.run_sync([decoded_logs])
@@ -335,7 +340,8 @@ def test_run_sync_with_warning_logs_400(
         with patch.dict("os.environ", {"DISCORD_URL": "https://discord.com/api/webhooks/test"}):
             output = DiscordOutput(urlparse(url), dummy_renv)
             raw_logs = [{} for _ in alchemy_sample_events]
-            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs, decoded_logs=alchemy_sample_events)
+            decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=raw_logs)
+            decoded_logs.decoded_logs = alchemy_sample_events
 
             with caplog.at_level("WARNING"):
                 output.run_sync([decoded_logs])
@@ -355,7 +361,7 @@ def test_build_transaction_messages_none_events(dummy_renv, mock_tx):
 async def test_send_to_output_sync_not_implemented(setup_output, mock_tx):
     output, queue, _ = setup_output
 
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[], decoded_logs=[])
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[])
 
     await queue.put(decoded_logs)
     with pytest.raises(NotImplementedError):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -45,8 +45,7 @@ def test_dummyoutput_send_to_output(dummy_output):
             }
         )
     ]
-    decoded_logs = ["decoded_event"]
-    decoded_tx_logs = DecodedTxLogs(tx=tx, raw_logs=raw_logs, decoded_logs=decoded_logs)
+    decoded_tx_logs = DecodedTxLogs(tx=tx, raw_logs=raw_logs)
 
     with patch("pprint.pprint") as mock_pprint:
         asyncio.run(dummy_output.send_to_output(decoded_tx_logs))
@@ -64,8 +63,7 @@ def test_dummyoutput_send_to_output_sync(dummy_output):
             }
         )
     ]
-    decoded_logs = ["decoded_event"]
-    decoded_tx_logs = DecodedTxLogs(tx=tx, raw_logs=raw_logs, decoded_logs=decoded_logs)
+    decoded_tx_logs = DecodedTxLogs(tx=tx, raw_logs=raw_logs)
 
     with patch("pprint.pprint") as mock_pprint:
         dummy_output.send_to_output_sync(decoded_tx_logs)
@@ -74,9 +72,9 @@ def test_dummyoutput_send_to_output_sync(dummy_output):
 
 def test_outputbase_run(dummy_output, queue):
     tx1 = Tx(block=None, hash=Hash("0xd77c733e1884cd516c042549861c93cad8b998f691c38682c6100d7872761d4a"), index=1)
-    decoded_tx_logs1 = DecodedTxLogs(tx=tx1, raw_logs=[], decoded_logs=[])
+    decoded_tx_logs1 = DecodedTxLogs(tx=tx1, raw_logs=[])
     tx2 = Tx(block=None, hash=Hash("0x4a76712bb2be112fd59f3a4f285dbc3c4b39914f557e5e336cf95b3cf4545328"), index=2)
-    decoded_tx_logs2 = DecodedTxLogs(tx=tx2, raw_logs=[], decoded_logs=[])
+    decoded_tx_logs2 = DecodedTxLogs(tx=tx2, raw_logs=[])
 
     asyncio.run(queue.put(decoded_tx_logs1))
     asyncio.run(queue.put(decoded_tx_logs2))
@@ -98,9 +96,9 @@ def test_outputbase_run(dummy_output, queue):
 
 def test_outputbase_run_sync(dummy_output):
     tx1 = Tx(block=None, hash=Hash("0xd77c733e1884cd516c042549861c93cad8b998f691c38682c6100d7872761d4a"), index=1)
-    decoded_tx_logs1 = DecodedTxLogs(tx=tx1, raw_logs=[], decoded_logs=[])
+    decoded_tx_logs1 = DecodedTxLogs(tx=tx1, raw_logs=[])
     tx2 = Tx(block=None, hash=Hash("0x4a76712bb2be112fd59f3a4f285dbc3c4b39914f557e5e336cf95b3cf4545328"), index=2)
-    decoded_tx_logs2 = DecodedTxLogs(tx=tx2, raw_logs=[], decoded_logs=[])
+    decoded_tx_logs2 = DecodedTxLogs(tx=tx2, raw_logs=[])
 
     logs = [decoded_tx_logs1, decoded_tx_logs2]
 

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -100,10 +100,9 @@ def mock_raw_log():
 def test_printoutput_unrecognized_event(dummy_renv, mock_tx, mock_raw_log, caplog):
     url = urlparse("print://")
     output = PrintOutput(url, dummy_renv)
-
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log], decoded_logs=[None])
-    with caplog.at_level("WARNING"):
-        output.send_to_output_sync(decoded_logs)
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log])
+    decoded_logs.decoded_logs = [None]
+    output.send_to_output_sync(decoded_logs)
 
     assert "Unrecognized event tried to be rendered in tx" in caplog.text
 
@@ -116,7 +115,8 @@ def test_printoutput_prints_event(
     url = urlparse("print://")
     output = PrintOutput(url, dummy_renv)
 
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log], decoded_logs=[mock_event])
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log])
+    decoded_logs.decoded_logs = [mock_event]
     output.send_to_output_sync(decoded_logs)
 
     captured = capfd.readouterr()
@@ -135,7 +135,7 @@ def test_printoutput_no_printing_event(dummy_renv, template_loader, mock_tx, moc
     url = urlparse("print://")
     output = PrintOutput(url, dummy_renv)
 
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[], decoded_logs=[mock_event])
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[])
     output.send_to_output_sync(decoded_logs)
 
     captured = capfd.readouterr()
@@ -166,7 +166,8 @@ def test_printoutput_decode_error_event(dummy_renv, template_loader, template_ru
     )
 
     mock_raw_log = MockRawLog(logIndex=5)
-    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log], decoded_logs=[decode_error_event])
+    decoded_logs = DecodedTxLogs(tx=mock_tx, raw_logs=[mock_raw_log])
+    decoded_logs.decoded_logs = [decode_error_event]
     output.send_to_output_sync(decoded_logs)
 
     captured = capfd.readouterr()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -87,7 +87,7 @@ def test_pubsub_raw_logs_output_with_dry_run(dummy_renv, caplog):
             "logIndex": 0,
         }
     ]
-    log = DecodedTxLogs(tx=tx, raw_logs=raw_logs, decoded_logs=[])
+    log = DecodedTxLogs(tx=tx, raw_logs=raw_logs)
 
     with caplog.at_level("INFO"):
         asyncio.run(output.send_to_output(log))
@@ -144,7 +144,7 @@ def test_pubsub_raw_logs_output_production(dummy_renv, mock_future):
                 "logIndex": 0,
             }
         ]
-        log = DecodedTxLogs(tx=tx, raw_logs=raw_logs, decoded_logs=[])
+        log = DecodedTxLogs(tx=tx, raw_logs=raw_logs)
 
         mock_publisher_instance.publish.return_value = mock_future()
 
@@ -210,7 +210,8 @@ def test_pubsub_decoded_logs_output_with_dry_run(dummy_renv, caplog):
             chain=Chain(id=1, name="Ethereum Mainnet"),
         ),
     )
-    log = DecodedTxLogs(tx=tx, raw_logs=[], decoded_logs=[decoded_event])
+    log = DecodedTxLogs(tx=tx, raw_logs=[])
+    log.decoded_logs = [decoded_event]
 
     with caplog.at_level("INFO"):
         asyncio.run(output.send_to_output(log))
@@ -287,7 +288,8 @@ def test_pubsub_decoded_logs_output_production(dummy_renv, mock_future):
                 chain=Chain(id=1, name="Ethereum Mainnet"),
             ),
         )
-        log = DecodedTxLogs(tx=tx, raw_logs=[], decoded_logs=[decoded_event])
+        log = DecodedTxLogs(tx=tx, raw_logs=[])
+        log.decoded_logs = [decoded_event]
 
         mock_publisher_instance.publish.return_value = mock_future()
 
@@ -389,7 +391,8 @@ def test_pubsub_decoded_logs_output_filters_decode_error(dummy_renv, caplog):
         error="LogTopicError: Unable to decode",
     )
 
-    log = DecodedTxLogs(tx=tx, raw_logs=[], decoded_logs=[decoded_event, decode_error])
+    log = DecodedTxLogs(tx=tx, raw_logs=[])
+    log.decoded_logs = [decoded_event, decode_error]
 
     with caplog.at_level("INFO"):
         asyncio.run(output.send_to_output(log))

--- a/tests/test_w3cache.py
+++ b/tests/test_w3cache.py
@@ -88,42 +88,60 @@ class TestW3Cache:
     def test_preload_receipts_with_batch_requests(self):
         mock_w3 = MagicMock()
         receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+        receipt1.blockNumber = 100
         receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
-        mock_batch = MagicMock()
-        mock_batch.execute.return_value = [receipt1, receipt2]
-        mock_w3.batch_requests.return_value = mock_batch
+        receipt2.blockNumber = 101
+
+        receipt_batch = MagicMock()
+        receipt_batch.execute.return_value = [receipt1, receipt2]
+
+        block1 = MagicMock()
+        block1.number = 100
+        block2 = MagicMock()
+        block2.number = 101
+        block_batch = MagicMock()
+        block_batch.execute.return_value = [block1, block2]
+
+        mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
 
         cache = W3Cache(mock_w3)
         cache.preload_receipts([TX_HASH_1, TX_HASH_2])
 
-        assert mock_w3.batch_requests.call_count == 1
-        mock_batch.add_mapping.assert_called_once()
-        assert mock_batch.execute.call_count == 1
+        assert mock_w3.batch_requests.call_count == 2
         assert TX_HASH_1.lower() in cache._receipt_cache
         assert TX_HASH_2.lower() in cache._receipt_cache
+        assert 100 in cache._block_cache
+        assert 101 in cache._block_cache
 
     def test_preload_receipts_skips_cached(self):
         mock_w3 = MagicMock()
         receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+        receipt1.blockNumber = 100
         receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
-        mock_batch = MagicMock()
-        mock_batch.execute.return_value = [receipt2]
-        mock_w3.batch_requests.return_value = mock_batch
+        receipt2.blockNumber = 101
+
+        receipt_batch = MagicMock()
+        receipt_batch.execute.return_value = [receipt2]
+
+        block_batch = MagicMock()
+        block_batch.execute.return_value = []
+
+        mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
 
         cache = W3Cache(mock_w3)
         cache._receipt_cache[TX_HASH_1.lower()] = receipt1
 
         cache.preload_receipts([TX_HASH_1, TX_HASH_2])
 
-        call_args = mock_batch.add_mapping.call_args[0][0]
-        assert TX_HASH_1.lower() not in call_args[mock_w3.eth.get_transaction_receipt]
-        assert TX_HASH_2.lower() in call_args[mock_w3.eth.get_transaction_receipt]
+        assert TX_HASH_2.lower() in cache._receipt_cache
+        assert TX_HASH_1.lower() not in receipt_batch.add_mapping.call_args[0][0][mock_w3.eth.get_transaction_receipt]
 
     def test_preload_receipts_batching(self):
         mock_w3 = MagicMock()
         receipts = [MagicMock() for i in range(60)]
         for i, r in enumerate(receipts):
             r.transactionHash = f"0x{i:064d}"
+            r.blockNumber = i % 3
 
         batches = []
         for i in range(0, 60, 50):
@@ -133,7 +151,20 @@ class TestW3Cache:
 
         mock_w3.batch_requests.side_effect = iter(batches)
 
+        block_batches = []
+        for i in range(0, 3, 50):
+            block_batch = MagicMock()
+            block_data = []
+            for j in range(i, min(i + 50, 3)):
+                b = MagicMock()
+                b.number = j
+                block_data.append(b)
+            block_batch.execute.return_value = block_data
+            block_batches.append(block_batch)
+
+        mock_w3.batch_requests.side_effect = iter(batches + block_batches)
+
         cache = W3Cache(mock_w3)
         cache.preload_receipts([r.transactionHash for r in receipts])
 
-        assert mock_w3.batch_requests.call_count == 2
+        assert mock_w3.batch_requests.call_count == 3

--- a/tests/test_w3cache.py
+++ b/tests/test_w3cache.py
@@ -1,0 +1,139 @@
+from unittest.mock import MagicMock
+
+from eth_pretty_events.w3cache import W3Cache
+
+TX_HASH_1 = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+TX_HASH_2 = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+
+class TestW3Cache:
+    def test_eth_property_returns_self(self):
+        mock_w3 = MagicMock()
+        cache = W3Cache(mock_w3)
+        assert cache.eth is cache
+
+    def test_is_connected(self):
+        mock_w3 = MagicMock()
+        mock_w3.is_connected = True
+        cache = W3Cache(mock_w3)
+        assert cache.is_connected() is True
+
+    def test_get_transaction_receipt_caches(self):
+        mock_w3 = MagicMock()
+        receipt = MagicMock(transactionHash=TX_HASH_1)
+        mock_w3.eth.get_transaction_receipt.return_value = receipt
+
+        cache = W3Cache(mock_w3)
+        result = cache.get_transaction_receipt(TX_HASH_1)
+
+        assert result is receipt
+        assert mock_w3.eth.get_transaction_receipt.call_count == 1
+        assert TX_HASH_1.lower() in cache._receipt_cache
+
+        result_cached = cache.get_transaction_receipt(TX_HASH_1)
+        assert result_cached is receipt
+        assert mock_w3.eth.get_transaction_receipt.call_count == 1
+
+    def test_get_transaction_receipt_normalizes_hash(self):
+        mock_w3 = MagicMock()
+        receipt = MagicMock(transactionHash=TX_HASH_1.lower())
+        mock_w3.eth.get_transaction_receipt.return_value = receipt
+
+        cache = W3Cache(mock_w3)
+        cache.get_transaction_receipt(TX_HASH_1.upper())
+
+        mock_w3.eth.get_transaction_receipt.assert_called_once()
+        assert TX_HASH_1.lower() in cache._receipt_cache
+
+    def test_get_block_by_number_caches(self):
+        mock_w3 = MagicMock()
+        block = {"number": 123, "timestamp": 999}
+        mock_w3.eth.get_block.return_value = block
+
+        cache = W3Cache(mock_w3)
+        result = cache.get_block(123)
+
+        assert result is block
+        assert mock_w3.eth.get_block.call_count == 1
+        assert 123 in cache._block_cache
+
+        result_cached = cache.get_block(123)
+        assert result_cached is block
+        assert mock_w3.eth.get_block.call_count == 1
+
+    def test_get_block_by_string_passthrough(self):
+        mock_w3 = MagicMock()
+        block = {"number": 123, "timestamp": 999}
+        mock_w3.eth.get_block.return_value = block
+
+        cache = W3Cache(mock_w3)
+        result = cache.get_block("latest")
+
+        assert result is block
+        mock_w3.eth.get_block.assert_called_once_with("latest")
+        assert 123 not in cache._block_cache
+
+    def test_get_logs_forward(self):
+        mock_w3 = MagicMock()
+        logs = [MagicMock()]
+        mock_w3.eth.get_logs.return_value = logs
+
+        filter_params = {"address": "0x123"}
+        cache = W3Cache(mock_w3)
+        result = cache.get_logs(filter_params)
+
+        assert result is logs
+        mock_w3.eth.get_logs.assert_called_once_with(filter_params)
+
+    def test_preload_receipts_with_batch_requests(self):
+        mock_w3 = MagicMock()
+        receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+        receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
+        mock_batch = MagicMock()
+        mock_batch.execute.return_value = [receipt1, receipt2]
+        mock_w3.batch_requests.return_value = mock_batch
+
+        cache = W3Cache(mock_w3)
+        cache.preload_receipts([TX_HASH_1, TX_HASH_2])
+
+        assert mock_w3.batch_requests.call_count == 1
+        mock_batch.add_mapping.assert_called_once()
+        assert mock_batch.execute.call_count == 1
+        assert TX_HASH_1.lower() in cache._receipt_cache
+        assert TX_HASH_2.lower() in cache._receipt_cache
+
+    def test_preload_receipts_skips_cached(self):
+        mock_w3 = MagicMock()
+        receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+        receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
+        mock_batch = MagicMock()
+        mock_batch.execute.return_value = [receipt2]
+        mock_w3.batch_requests.return_value = mock_batch
+
+        cache = W3Cache(mock_w3)
+        cache._receipt_cache[TX_HASH_1.lower()] = receipt1
+
+        cache.preload_receipts([TX_HASH_1, TX_HASH_2])
+
+        call_args = mock_batch.add_mapping.call_args[0][0]
+        assert TX_HASH_1.lower() not in call_args[mock_w3.eth.get_transaction_receipt]
+        assert TX_HASH_2.lower() in call_args[mock_w3.eth.get_transaction_receipt]
+
+    def test_preload_receipts_batching(self):
+        mock_w3 = MagicMock()
+        receipts = [MagicMock() for i in range(60)]
+        for i, r in enumerate(receipts):
+            r.transactionHash = f"0x{i:064d}"
+
+        batches = []
+        for i in range(0, 60, 50):
+            batch = MagicMock()
+            batch.execute.return_value = receipts[i : i + 50]
+            batches.append(batch)
+
+        mock_w3.batch_requests.side_effect = iter(batches)
+
+        cache = W3Cache(mock_w3)
+        cache.preload_receipts([r.transactionHash for r in receipts])
+
+        assert mock_w3.batch_requests.call_count == 2

--- a/tests/test_w3cache.py
+++ b/tests/test_w3cache.py
@@ -1,170 +1,167 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from eth_pretty_events.w3cache import W3Cache
 
 TX_HASH_1 = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 TX_HASH_2 = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
 
 
-class TestW3Cache:
-    def test_eth_property_returns_self(self):
-        mock_w3 = MagicMock()
-        cache = W3Cache(mock_w3)
-        assert cache.eth is cache
+@pytest.fixture
+def mock_w3():
+    return MagicMock()
 
-    def test_is_connected(self):
-        mock_w3 = MagicMock()
-        mock_w3.is_connected = True
-        cache = W3Cache(mock_w3)
-        assert cache.is_connected() is True
 
-    def test_get_transaction_receipt_caches(self):
-        mock_w3 = MagicMock()
-        receipt = MagicMock(transactionHash=TX_HASH_1)
-        mock_w3.eth.get_transaction_receipt.return_value = receipt
+@pytest.fixture
+def cache(mock_w3):
+    return W3Cache(mock_w3)
 
-        cache = W3Cache(mock_w3)
-        result = cache.get_transaction_receipt(TX_HASH_1)
 
-        assert result is receipt
-        assert mock_w3.eth.get_transaction_receipt.call_count == 1
-        assert TX_HASH_1.lower() in cache._receipt_cache
+def test_eth_property_returns_self(mock_w3):
+    cache = W3Cache(mock_w3)
+    assert cache.eth is cache
+    assert cache._w3 is mock_w3
 
-        result_cached = cache.get_transaction_receipt(TX_HASH_1)
-        assert result_cached is receipt
-        assert mock_w3.eth.get_transaction_receipt.call_count == 1
 
-    def test_get_transaction_receipt_normalizes_hash(self):
-        mock_w3 = MagicMock()
-        receipt = MagicMock(transactionHash=TX_HASH_1.lower())
-        mock_w3.eth.get_transaction_receipt.return_value = receipt
+def test_get_transaction_receipt_caches(mock_w3, cache):
+    receipt = MagicMock(transactionHash=TX_HASH_1)
+    mock_w3.eth.get_transaction_receipt.return_value = receipt
 
-        cache = W3Cache(mock_w3)
-        cache.get_transaction_receipt(TX_HASH_1.upper())
+    result = cache.get_transaction_receipt(TX_HASH_1)
 
-        mock_w3.eth.get_transaction_receipt.assert_called_once()
-        assert TX_HASH_1.lower() in cache._receipt_cache
+    assert result is receipt
+    assert mock_w3.eth.get_transaction_receipt.call_count == 1
+    assert TX_HASH_1.lower() in cache._receipt_cache
 
-    def test_get_block_by_number_caches(self):
-        mock_w3 = MagicMock()
-        block = {"number": 123, "timestamp": 999}
-        mock_w3.eth.get_block.return_value = block
+    result_cached = cache.get_transaction_receipt(TX_HASH_1)
+    assert result_cached is receipt
+    assert mock_w3.eth.get_transaction_receipt.call_count == 1
 
-        cache = W3Cache(mock_w3)
-        result = cache.get_block(123)
 
-        assert result is block
-        assert mock_w3.eth.get_block.call_count == 1
-        assert 123 in cache._block_cache
+def test_get_transaction_receipt_normalizes_hash(mock_w3, cache):
+    receipt = MagicMock(transactionHash=TX_HASH_1.lower())
+    mock_w3.eth.get_transaction_receipt.return_value = receipt
 
-        result_cached = cache.get_block(123)
-        assert result_cached is block
-        assert mock_w3.eth.get_block.call_count == 1
+    cache.get_transaction_receipt(TX_HASH_1.upper())
 
-    def test_get_block_by_string_passthrough(self):
-        mock_w3 = MagicMock()
-        block = {"number": 123, "timestamp": 999}
-        mock_w3.eth.get_block.return_value = block
+    mock_w3.eth.get_transaction_receipt.assert_called_once()
+    assert TX_HASH_1.lower() in cache._receipt_cache
 
-        cache = W3Cache(mock_w3)
-        result = cache.get_block("latest")
 
-        assert result is block
-        mock_w3.eth.get_block.assert_called_once_with("latest")
-        assert 123 not in cache._block_cache
+def test_get_block_by_number_caches(mock_w3, cache):
+    block = {"number": 123, "timestamp": 999}
+    mock_w3.eth.get_block.return_value = block
 
-    def test_get_logs_forward(self):
-        mock_w3 = MagicMock()
-        logs = [MagicMock()]
-        mock_w3.eth.get_logs.return_value = logs
+    result = cache.get_block(123)
 
-        filter_params = {"address": "0x123"}
-        cache = W3Cache(mock_w3)
-        result = cache.get_logs(filter_params)
+    assert result is block
+    assert mock_w3.eth.get_block.call_count == 1
+    assert 123 in cache._block_cache
 
-        assert result is logs
-        mock_w3.eth.get_logs.assert_called_once_with(filter_params)
+    result_cached = cache.get_block(123)
+    assert result_cached is block
+    assert mock_w3.eth.get_block.call_count == 1
 
-    def test_preload_receipts_with_batch_requests(self):
-        mock_w3 = MagicMock()
-        receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
-        receipt1.blockNumber = 100
-        receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
-        receipt2.blockNumber = 101
 
-        receipt_batch = MagicMock()
-        receipt_batch.execute.return_value = [receipt1, receipt2]
+def test_get_block_by_string_passthrough(mock_w3, cache):
+    block = {"number": 123, "timestamp": 999}
+    mock_w3.eth.get_block.return_value = block
 
-        block1 = MagicMock()
-        block1.number = 100
-        block2 = MagicMock()
-        block2.number = 101
+    result = cache.get_block("latest")
+
+    assert result is block
+    mock_w3.eth.get_block.assert_called_once_with("latest")
+    assert 123 not in cache._block_cache
+
+
+def test_get_logs_forward(mock_w3, cache):
+    logs = [MagicMock()]
+    mock_w3.eth.get_logs.return_value = logs
+
+    filter_params = {"address": "0x123"}
+    result = cache.get_logs(filter_params)
+
+    assert result is logs
+    mock_w3.eth.get_logs.assert_called_once_with(filter_params)
+
+
+def test_preload_receipts_with_batch_requests(mock_w3, cache):
+    receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+    receipt1.blockNumber = 100
+    receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
+    receipt2.blockNumber = 101
+
+    receipt_batch = MagicMock()
+    receipt_batch.execute.return_value = [receipt1, receipt2]
+
+    block1 = MagicMock()
+    block1.number = 100
+    block2 = MagicMock()
+    block2.number = 101
+    block_batch = MagicMock()
+    block_batch.execute.return_value = [block1, block2]
+
+    mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
+
+    cache.preload_receipts([TX_HASH_1, TX_HASH_2])
+
+    assert mock_w3.batch_requests.call_count == 2
+    assert TX_HASH_1.lower() in cache._receipt_cache
+    assert TX_HASH_2.lower() in cache._receipt_cache
+    assert 100 in cache._block_cache
+    assert 101 in cache._block_cache
+
+
+def test_preload_receipts_skips_cached(mock_w3, cache):
+    receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
+    receipt1.blockNumber = 100
+    receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
+    receipt2.blockNumber = 101
+
+    receipt_batch = MagicMock()
+    receipt_batch.execute.return_value = [receipt2]
+
+    block_batch = MagicMock()
+    block_batch.execute.return_value = []
+
+    mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
+
+    cache._receipt_cache[TX_HASH_1.lower()] = receipt1
+
+    cache.preload_receipts([TX_HASH_1, TX_HASH_2])
+
+    assert TX_HASH_2.lower() in cache._receipt_cache
+    assert TX_HASH_1.lower() not in receipt_batch.add_mapping.call_args[0][0][mock_w3.eth.get_transaction_receipt]
+
+
+def test_preload_receipts_batching(mock_w3, cache):
+    receipts = [MagicMock() for i in range(60)]
+    for i, r in enumerate(receipts):
+        r.transactionHash = f"0x{i:064d}"
+        r.blockNumber = i % 3
+
+    batches = []
+    for i in range(0, 60, 50):
+        batch = MagicMock()
+        batch.execute.return_value = receipts[i : i + 50]
+        batches.append(batch)
+
+    mock_w3.batch_requests.side_effect = iter(batches)
+
+    block_batches = []
+    for i in range(0, 3, 50):
         block_batch = MagicMock()
-        block_batch.execute.return_value = [block1, block2]
+        block_data = []
+        for j in range(i, min(i + 50, 3)):
+            b = MagicMock()
+            b.number = j
+            block_data.append(b)
+        block_batch.execute.return_value = block_data
+        block_batches.append(block_batch)
 
-        mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
+    mock_w3.batch_requests.side_effect = iter(batches + block_batches)
 
-        cache = W3Cache(mock_w3)
-        cache.preload_receipts([TX_HASH_1, TX_HASH_2])
+    cache.preload_receipts([r.transactionHash for r in receipts])
 
-        assert mock_w3.batch_requests.call_count == 2
-        assert TX_HASH_1.lower() in cache._receipt_cache
-        assert TX_HASH_2.lower() in cache._receipt_cache
-        assert 100 in cache._block_cache
-        assert 101 in cache._block_cache
-
-    def test_preload_receipts_skips_cached(self):
-        mock_w3 = MagicMock()
-        receipt1 = MagicMock(transactionHash=TX_HASH_1.lower())
-        receipt1.blockNumber = 100
-        receipt2 = MagicMock(transactionHash=TX_HASH_2.lower())
-        receipt2.blockNumber = 101
-
-        receipt_batch = MagicMock()
-        receipt_batch.execute.return_value = [receipt2]
-
-        block_batch = MagicMock()
-        block_batch.execute.return_value = []
-
-        mock_w3.batch_requests.side_effect = [receipt_batch, block_batch]
-
-        cache = W3Cache(mock_w3)
-        cache._receipt_cache[TX_HASH_1.lower()] = receipt1
-
-        cache.preload_receipts([TX_HASH_1, TX_HASH_2])
-
-        assert TX_HASH_2.lower() in cache._receipt_cache
-        assert TX_HASH_1.lower() not in receipt_batch.add_mapping.call_args[0][0][mock_w3.eth.get_transaction_receipt]
-
-    def test_preload_receipts_batching(self):
-        mock_w3 = MagicMock()
-        receipts = [MagicMock() for i in range(60)]
-        for i, r in enumerate(receipts):
-            r.transactionHash = f"0x{i:064d}"
-            r.blockNumber = i % 3
-
-        batches = []
-        for i in range(0, 60, 50):
-            batch = MagicMock()
-            batch.execute.return_value = receipts[i : i + 50]
-            batches.append(batch)
-
-        mock_w3.batch_requests.side_effect = iter(batches)
-
-        block_batches = []
-        for i in range(0, 3, 50):
-            block_batch = MagicMock()
-            block_data = []
-            for j in range(i, min(i + 50, 3)):
-                b = MagicMock()
-                b.number = j
-                block_data.append(b)
-            block_batch.execute.return_value = block_data
-            block_batches.append(block_batch)
-
-        mock_w3.batch_requests.side_effect = iter(batches + block_batches)
-
-        cache = W3Cache(mock_w3)
-        cache.preload_receipts([r.transactionHash for r in receipts])
-
-        assert mock_w3.batch_requests.call_count == 3
+    assert mock_w3.batch_requests.call_count == 3


### PR DESCRIPTION
## Summary
- Add W3Cache class that wraps Web3 with caching for TX receipts and blocks
- Cache TX receipts by hash (lowercase normalized)
- Cache blocks by integer block number
- Add preload_receipts() method using web3.py batch requests (batch_size=50)
- eth property returns self for drop-in compatibility with decode_events
- Use W3Cache in render_events for .txt input type

## Motivation
When processing multiple TX hashes from a .txt file, each TX requires two RPC calls (get_transaction_receipt, get_block). The W3Cache eliminates redundant calls by caching results within a single run.